### PR TITLE
PS-3096: [backward compatibility][case5] Unable to View order in Zed / Yves

### DIFF
--- a/src/Spryker/Zed/Sales/Presentation/Detail/boxes/order-item-option.twig
+++ b/src/Spryker/Zed/Sales/Presentation/Detail/boxes/order-item-option.twig
@@ -14,7 +14,7 @@
         <td>
 
             <div>
-                {% embed '@Sales/Detail/boxes/discounted-price.twig' with {subtotal: productOption.sumPrice, priceToPay: productOption.sumPrice - productOption.sumDiscountAmountFullAggregation | default(0)} %} {% endembed %}
+                {% embed '@Sales/Detail/boxes/discounted-price.twig' with {subtotal: productOption.sumPrice | default(productOption.unitPrice), priceToPay: (productOption.sumPrice | default(productOption.unitPrice)) - productOption.sumDiscountAmountFullAggregation | default(0)} %} {% endembed %}
             </div>
             <div class="tax-info">incl. {{ productOption.taxRate|default(0) }} % tax </div>
         </td>

--- a/src/Spryker/Zed/Sales/Presentation/Detail/boxes/totals.twig
+++ b/src/Spryker/Zed/Sales/Presentation/Detail/boxes/totals.twig
@@ -18,7 +18,7 @@
                             <tr>
                                 <td> + <span class="label">{{ 'Option' | trans }}</span> {{ orderItemOption.value }}</td>
                                 <td></td>
-                                <td class="text-right">{{ orderItemOption.sumPrice | money(true, order.currencyIsoCode) }}</td>
+                                <td class="text-right">{{ (orderItemOption.sumPrice | default(orderItemOption.unitPrice)) | money(true, order.currencyIsoCode) }}</td>
                                 <td></td>
                             </tr>
                         {% endfor %}
@@ -43,7 +43,7 @@
                                     <tr>
                                         <td></td>
                                         <td> + {{ orderItemOption.value }}</td>
-                                        <td class="text-right">{{ orderItemOption.sumPrice | money(true, order.currencyIsoCode)  }}</td>
+                                        <td class="text-right">{{ (orderItemOption.sumPrice | default(orderItemOption.unitPrice)) | money(true, order.currencyIsoCode)  }}</td>
                                         <td></td>
                                     </tr>
                                 {% endfor %}


### PR DESCRIPTION
Branch: backport/8.18.4
Ticket: https://spryker.atlassian.net/browse/PS-3096

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Sales               | patch                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Sales

##### Change log

Improvements

- Adjusted `order-item-option.twig` so now has fallback for `productOption.sumPrice`.
- Adjusted `totals.twig` so now has fallback for `productOption.sumPrice`.
