### PR TITLE
GLUE-5578 backport of the new version of the fix.

### DIFF
--- a/src/Spryker/Zed/Sales/Business/Model/Customer/PaginatedCustomerOrderReader.php
+++ b/src/Spryker/Zed/Sales/Business/Model/Customer/PaginatedCustomerOrderReader.php
@@ -8,6 +8,7 @@
 namespace Spryker\Zed\Sales\Business\Model\Customer;
 
 use Generated\Shared\Transfer\OrderListTransfer;
+use Generated\Shared\Transfer\PaginationTransfer;
 use Orm\Zed\Sales\Persistence\SpySalesOrderQuery;
 
 class PaginatedCustomerOrderReader extends CustomerOrderReader
@@ -31,7 +32,7 @@ class PaginatedCustomerOrderReader extends CustomerOrderReader
 
         $orderListTransfer->setOrders($orders);
 
-        return $orderListTransfer;
+        return $this->updatePaginationTransfer($orderListTransfer, $ordersQuery);
     }
 
     /**
@@ -83,5 +84,19 @@ class PaginatedCustomerOrderReader extends CustomerOrderReader
         $collection = $paginationModel->getResults();
 
         return $collection;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\OrderListTransfer $orderListTransfer
+     * @param \Orm\Zed\Sales\Persistence\SpySalesOrderQuery $ordersQuery
+     *
+     * @return \Generated\Shared\Transfer\OrderListTransfer
+     */
+    protected function updatePaginationTransfer(OrderListTransfer $orderListTransfer, SpySalesOrderQuery $ordersQuery): OrderListTransfer
+    {
+        if ($orderListTransfer->getPagination()) {
+            return $orderListTransfer;
+        }
+        return $orderListTransfer->setPagination((new PaginationTransfer())->setNbResults($ordersQuery->count()));
     }
 }


### PR DESCRIPTION
Branch: `backport/glue-5578-glue-api-pagination-offset-bug`.
Ticket: https://spryker.atlassian.net/browse/GLUE-5578.
Main PR: https://github.com/spryker/spryker/pull/6012.
Target version: **8.20.0**

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Sales               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Sales

##### Change log

### Improvements

- Adjusted `PaginatedCustomerOrderReader` so that it updates the `OrderListTransfer::$pagination` in case the `OrderListTransfer::$filter` is used to paginate with the offset-based pagination strategy.
