### PR TITLE
[PS-10211] Configurable bundle Zed UI (phase 1)

### DIFF
--- a/src/Spryker/Zed/Sales/Presentation/Detail/boxes/configured-bundle.twig
+++ b/src/Spryker/Zed/Sales/Presentation/Detail/boxes/configured-bundle.twig
@@ -2,7 +2,7 @@
 {% for bundle in order.salesOrderConfiguredBundles %}
     <tr>
         <td colspan="5">
-            {{ bundle.name | trans }}
+            {{ (bundle.translations[0].name ?? bundle.name) | trans }}
             ({{ 'ID:' | trans }} {{ bundle.configurableBundleTemplateUuid }})
         </td>
         <td>


### PR DESCRIPTION
Branch: backport/ps-10211/sales-10.3.2
Ticket: https://spryker.atlassian.net/browse/PS-10211
Target Version: 10.3.2

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Sales               | patch                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Sales

##### Change log

Improvements

- Adjusted `configured-bundle.twig` to support template name translation via translations array in a backward-compatible way.
