### PR TITLE
:bug: fix fetchting customer orders in zed

### DIFF
--- a/src/Spryker/Zed/Sales/Communication/Controller/CustomerController.php
+++ b/src/Spryker/Zed/Sales/Communication/Controller/CustomerController.php
@@ -42,7 +42,7 @@ class CustomerController extends AbstractController
      */
     public function ordersTableAction(Request $request)
     {
-        $customerReference = (string)$request->query->getAlpha(SalesConfig::PARAM_CUSTOMER_REFERENCE);
+        $customerReference = (string)$request->query->get(SalesConfig::PARAM_CUSTOMER_REFERENCE);
         $ordersTable = $this->getFactory()->createCustomerOrdersTable($customerReference);
 
         return $this->jsonResponse($ordersTable->fetchData());


### PR DESCRIPTION
## PR Description

The function 'getAlpha' will only allow alphanumeric. So for customer references like REF-000001 the -000001 will be stripped. So no orders in backend will be shown for customer. Switching getAlpha to get will fix the issue.

## Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
