### PR TITLE
CC-25414 Backport for adding binding of parameters to separate user input from the query.

### DIFF
--- a/src/Spryker/Zed/Sales/Persistence/Propel/QueryBuilder/OrderSearchQueryJoinQueryBuilder.php
+++ b/src/Spryker/Zed/Sales/Persistence/Propel/QueryBuilder/OrderSearchQueryJoinQueryBuilder.php
@@ -13,7 +13,6 @@ use Generated\Shared\Transfer\QueryJoinTransfer;
 use Generated\Shared\Transfer\QueryWhereConditionTransfer;
 use Orm\Zed\Sales\Persistence\SpySalesOrderQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
-use Propel\Runtime\ActiveQuery\Criterion\CustomCriterion;
 
 class OrderSearchQueryJoinQueryBuilder implements OrderSearchQueryJoinQueryBuilderInterface
 {
@@ -237,21 +236,11 @@ class OrderSearchQueryJoinQueryBuilder implements OrderSearchQueryJoinQueryBuild
         $value = $queryWhereConditionTransfer->getValue();
         $comparison = $queryWhereConditionTransfer->getComparison() ?? Criteria::LIKE;
 
-        if (mb_strpos($column, static::CONCAT) !== false) {
-            return $salesOrderQuery->addCond(
-                $conditionName,
-                new CustomCriterion(new Criteria(), sprintf('%s%s\'%%%s%%\'', $column, $comparison, $value)),
-                null,
-                Criteria::CUSTOM,
-            );
+        if ($comparison === Criteria::LIKE) {
+            $value = $this->formatFilterValue($value);
         }
 
-        return $salesOrderQuery->addCond(
-            $conditionName,
-            $column,
-            $comparison === Criteria::LIKE ? $this->formatFilterValue($value) : $value,
-            $comparison,
-        );
+        return $salesOrderQuery->addCond($conditionName, $column, $value, $comparison);
     }
 
     /**

--- a/src/Spryker/Zed/Sales/Persistence/Propel/QueryBuilder/OrderSearchQueryJoinQueryBuilder.php
+++ b/src/Spryker/Zed/Sales/Persistence/Propel/QueryBuilder/OrderSearchQueryJoinQueryBuilder.php
@@ -17,6 +17,8 @@ use Propel\Runtime\ActiveQuery\Criteria;
 class OrderSearchQueryJoinQueryBuilder implements OrderSearchQueryJoinQueryBuilderInterface
 {
     /**
+     * @deprecated Will be removed without replacement.
+     *
      * @var string
      */
     protected const CONCAT = 'CONCAT';


### PR DESCRIPTION
Branch: backport/11.30.2
Ticket: https://spryker.atlassian.net/browse/CC-25414
Version: 11.30.2
- Strategy: minor

Release URL: https://release.spryker.com/release/hotfix?type=&pr=https%3A%2F%2Fgithub.com%2Fspryker%2Fsales%2Fpull%2F11

#### Release Table

   Module                | Release Type         | Constraint Updates         
   :--------------------- | :------------------------ | :---------------------  |
   Sales  | patch                 |                        |

-----------------------------------------

#### Module Sales

##### Change log

Improvements

- Adjusted `OrderSearchQueryJoinQueryBuilder::addSalesOrderQueryFilters()` in order to separate user input from the query.
- Impacted `SalesFacade::searchOrders()` with these changes.
